### PR TITLE
added support for setting a parameter if the default value is null

### DIFF
--- a/src/main/java/com/github/markusbernhardt/seleniumlibrary/keywords/Robot.java
+++ b/src/main/java/com/github/markusbernhardt/seleniumlibrary/keywords/Robot.java
@@ -27,7 +27,7 @@ public class Robot {
 		if (givenValue != null && !givenValue.equals("None") && givenValue.length() > 0) {
 			if (defaultValue instanceof Map) {
 				value = (T) parseRobotDictionary(givenValue);
-			} else if (defaultValue instanceof String) {
+			} else if (defaultValue instanceof String || defaultValue == null) {
 				value = (T) givenValue;
 			} else if (defaultValue instanceof List) {
 				value = (T) parseRobotList(givenValue);


### PR DESCRIPTION
I noticed that setting a custom filename for a screenshot using the "Capture Page Screenshot" keyword wasn't working.

This seems to be because the default value for [getParamsValue() was set to null](https://github.com/Hi-Fi/robotframework-seleniumlibrary-java/blob/76b4bc81d6e029389ad9e7b9facae09f9386e02c/src/main/java/com/github/markusbernhardt/seleniumlibrary/keywords/Screenshot.java#L62), which isn't supported by the method. 