### PR TITLE
Use of {index} in the filename of a screenshot

### DIFF
--- a/src/main/java/com/github/markusbernhardt/seleniumlibrary/keywords/Screenshot.java
+++ b/src/main/java/com/github/markusbernhardt/seleniumlibrary/keywords/Screenshot.java
@@ -54,8 +54,10 @@ public class Screenshot extends RunOnFailureKeywordsAdapter {
 	
 	@RobotKeyword("Take a screenshot of the current page and embed it into the log.\r\n" + 
 	        "\r\n" + 
-	        "The ``filename`` argument specifies the name of the file to write the screenshot into. If no filename is given, the screenshot is saved into file selenium-screenshot-<counter>.png under the directory where the Robot Framework log file is written into. The filename is also considered relative to the same directory, if it is not given in absolute format.\r\n" + 
+	        "The ``filename`` argument specifies the name of the file to write the screenshot into. If no filename is given, the screenshot is saved into file selenium-screenshot-{index}.png under the directory where the Robot Framework log file is written into. The filename is also considered relative to the same directory, if it is not given in absolute format.\r\n" + 
 	        "\r\n" + 
+		"if ``filename`` contains marker {index}, it will be automatically replaced with unique running index preventing files to be overwritten. Indices start from 1.\r\n" +
+		"\r\n" + 
 	        "A CSS can be used to modify how the screenshot is taken. By default the background color is changed to avoid possible problems with background leaking when the page layout is somehow broken.")
 	@ArgumentNames({ "filename=NONE" })
 	public void capturePageScreenshot(String...params) {


### PR DESCRIPTION
Add the possibility to use {index} in the filename of the Capture Page Screenshot keyword like in the original SeleniumLibrary. http://robotframework.org/Selenium2Library/Selenium2Library.html#Capture%20Page%20Screenshot