### PR TITLE
Fix incorrect locator deprecation warnings

### DIFF
--- a/src/main/java/com/github/markusbernhardt/seleniumlibrary/keywords/Element.java
+++ b/src/main/java/com/github/markusbernhardt/seleniumlibrary/keywords/Element.java
@@ -757,7 +757,7 @@ public class Element extends RunOnFailureKeywordsAdapter {
 	public ArrayList<String> getAllLinks() {
 		ArrayList<String> ret = new ArrayList<String>();
 
-		List<WebElement> elements = elementFind("tag=a", false, false, "a");
+		List<WebElement> elements = elementFind("tag:a", false, false, "a");
 		for (WebElement element : elements) {
 			ret.add(element.getAttribute("id"));
 		}
@@ -861,8 +861,8 @@ public class Element extends RunOnFailureKeywordsAdapter {
 	        "If you wish to assert the number of located elements, use `Xpath Should Match X Times`.")
 	@ArgumentNames({ "xpath" })
 	public int getMatchingXpathCount(String xpath) {
-		if (!xpath.startsWith("xpath=")) {
-			xpath = "xpath=" + xpath;
+		if (!xpath.startsWith("xpath=") && !xpath.startsWith("xpath:")) {
+			xpath = "xpath:" + xpath;
 		}
 		List<WebElement> elements = elementFind(xpath, false, false);
 
@@ -874,8 +874,8 @@ public class Element extends RunOnFailureKeywordsAdapter {
 	public void xpathShouldMatchXTimes(String xpath, int expectedXpathCount, String...params) {
         String message = robot.getParamsValue(params, 0, "");
         String logLevel = robot.getParamsValue(params, 1, "INFO");
-		if (!xpath.startsWith("xpath=")) {
-			xpath = "xpath=" + xpath;
+		if (!xpath.startsWith("xpath=") && !xpath.startsWith("xpath:")) {
+			xpath = "xpath:" + xpath;
 		}
 		List<WebElement> elements = elementFind(xpath, false, false);
 		int actualXpathCount = elements.size();
@@ -932,7 +932,7 @@ public class Element extends RunOnFailureKeywordsAdapter {
 	}
 
 	protected boolean isTextPresent(String text) {
-		String locator = String.format("xpath=//*[contains(., %s)]", escapeXpathValue(text));
+		String locator = String.format("xpath://*[contains(., %s)]", escapeXpathValue(text));
 
 		return isElementPresent(locator);
 	}
@@ -1015,7 +1015,7 @@ public class Element extends RunOnFailureKeywordsAdapter {
 			return true;
 		}
 
-		List<WebElement> elements = elementFind("xpath=//frame|//iframe", false, false);
+		List<WebElement> elements = elementFind("xpath://frame|//iframe", false, false);
 		Iterator<WebElement> it = elements.iterator();
 		while (it.hasNext()) {
 			current.switchTo().frame(it.next());

--- a/src/main/java/com/github/markusbernhardt/seleniumlibrary/keywords/FormElement.java
+++ b/src/main/java/com/github/markusbernhardt/seleniumlibrary/keywords/FormElement.java
@@ -49,7 +49,7 @@ public class FormElement extends RunOnFailureKeywordsAdapter {
 	public void submitForm(String locator) {
 		logging.info(String.format("Submitting form '%s'.", locator));
 		if (locator == null) {
-			locator = "xpath=//form";
+			locator = "xpath://form";
 		}
 		List<WebElement> webElements = element.elementFind(locator, true, true, "form");
 		webElements.get(0).submit();
@@ -428,13 +428,13 @@ public class FormElement extends RunOnFailureKeywordsAdapter {
 	}
 
 	protected List<WebElement> getRadioButtons(String groupName) {
-		String xpath = String.format("xpath=//input[@type='radio' and @name='%s']", groupName);
+		String xpath = String.format("xpath://input[@type='radio' and @name='%s']", groupName);
 		logging.debug("Radio group locator: " + xpath);
 		return element.elementFind(xpath, false, true);
 	}
 
 	protected WebElement getRadioButtonWithValue(String groupName, String value) {
-		String xpath = String.format("xpath=//input[@type='radio' and @name='%s' and (@value='%s' or @id='%s')]",
+		String xpath = String.format("xpath://input[@type='radio' and @name='%s' and (@value='%s' or @id='%s')]",
 				groupName, value, value);
 		logging.debug("Radio group locator: " + xpath);
 		return element.elementFind(xpath, true, true).get(0);

--- a/src/main/java/com/github/markusbernhardt/seleniumlibrary/locators/TableElementFinder.java
+++ b/src/main/java/com/github/markusbernhardt/seleniumlibrary/locators/TableElementFinder.java
@@ -85,13 +85,14 @@ public class TableElementFinder {
 	protected static List<String> parseTableLocator(String tableLocator, String locationMethod) {
 		String tableLocatorType = null;
 
-		if (tableLocator.startsWith("xpath=")) {
+		if (tableLocator.startsWith("xpath=") || tableLocator.startsWith("xpath:")) {
 			tableLocatorType = "xpath.";
-		} else if (tableLocator.startsWith("jquery=") || tableLocator.startsWith("sizzle=")) {
+		} else if (tableLocator.startsWith("jquery=") || tableLocator.startsWith("jquery:") ||
+				tableLocator.startsWith("sizzle=") || tableLocator.startsWith("sizzle:")) {
 			tableLocatorType = "sizzle.";
 		} else {
-			if (!tableLocator.startsWith("css=")) {
-				tableLocator = String.format("css=table#%s", tableLocator);
+			if (!tableLocator.startsWith("css=") && !tableLocator.startsWith("css:")) {
+				tableLocator = String.format("css:table#%s", tableLocator);
 			}
 			tableLocatorType = "css.";
 		}


### PR DESCRIPTION
Keywords like Page Should Contain and Get Table Cell caused deprecation warnings, even when using the new locator syntax or without any locators.
```
[ WARN ] '=' is deprecated as locator strategy separator. ':' should be used instead
```
This PR changes internally generated locators to use the new ':' format.