### PR TITLE
Added setFocusToElement to replace the Focus keyword

### DIFF
--- a/src/main/java/com/github/markusbernhardt/seleniumlibrary/keywords/Element.java
+++ b/src/main/java/com/github/markusbernhardt/seleniumlibrary/keywords/Element.java
@@ -429,18 +429,32 @@ public class Element extends RunOnFailureKeywordsAdapter {
             "\r\n" +
             "The ``attribute_locator`` consists of element locator followed by an @ sign and attribute name. Example: element_id@class\r\n" +
             "\r\n" +
-            "Key attributes for arbitrary elements are id and name. See `Introduction` for details about locators.")
+            "Key attributes for arbitrary elements are id and name. See `Introduction` for details about locators.\r\n" +
+            "\r\n" +
+            "Passing attribute name as part of the locator was removed in SeleniumLibrary 3.2. The explicit attribute argument should be used instead.")
     @ArgumentNames({ "attributeLocator" })
+    @Deprecated
     public String getElementAttribute(String attributeLocator) {
         String[] parts = parseAttributeLocator(attributeLocator);
+        return getElementAttribute(parts[0], parts[1]);
+    }
 
-        List<WebElement> elements = elementFind(parts[0], true, false);
+    @RobotKeyword("Returns value of attribute from element locator.\r\n" +
+            "\r\n" +
+            "See the `Locating elements` section for details about the locator syntax.\r\n" +
+            "\r\n" +
+            "Example: ${id}=    Get Element Attribute   css:h1  id\r\n" +
+            "\r\n" +
+            "Passing attribute name as part of the locator was removed in SeleniumLibrary 3.2. The explicit attribute argument should be used instead.")
+    @ArgumentNames({ "locator", "attribute" })
+    public String getElementAttribute(String locator, String attribute) {
+
+        List<WebElement> elements = elementFind(locator, true, false);
 
         if (elements.size() == 0) {
-            throw new SeleniumLibraryNonFatalException(String.format("Element '%s' not found.", parts[0]));
+            throw new SeleniumLibraryNonFatalException(String.format("Element '%s' not found.", locator));
         }
-
-        return elements.get(0).getAttribute(parts[1]);
+        return elements.get(0).getAttribute(attribute);
     }
 
     @RobotKeyword("Clears the text from element identified by ``locator``.\r\n" +

--- a/src/main/java/com/github/markusbernhardt/seleniumlibrary/keywords/Element.java
+++ b/src/main/java/com/github/markusbernhardt/seleniumlibrary/keywords/Element.java
@@ -247,8 +247,8 @@ public class Element extends RunOnFailureKeywordsAdapter {
                 .executeScript(String.format("arguments[0].id = '%s';", id), elements.get(0));
     }
 
-    @RobotKeyword("Verify the element identified by ``locator`` is found on the current page\r\n" + 
-            "\r\n" + 
+    @RobotKeyword("Verify the element identified by ``locator`` is enabled\r\n" +
+            "\r\n" +
             "Key attributes for arbitrary elements are id and name. See `Introduction` for details about log levels and locators.")
     @ArgumentNames({ "locator" })
     public void elementShouldBeEnabled(String locator) {
@@ -257,13 +257,23 @@ public class Element extends RunOnFailureKeywordsAdapter {
         }
     }
 
-    @RobotKeyword("Verify the element identified by ``locator`` is disabled.\r\n" + 
+    @RobotKeyword("Verify the element identified by ``locator`` is disabled.\r\n" +
             "\r\n" + 
             "Key attributes for arbitrary elements are id and name. See `Introduction` for details about locators.")
     @ArgumentNames({ "locator" })
     public void elementShouldBeDisabled(String locator) {
         if (isEnabled(locator)) {
             throw new SeleniumLibraryNonFatalException(String.format("Element %s is enabled.", locator));
+        }
+    }
+
+    @RobotKeyword("Verify the element identified by ``locator`` is focused\r\n" +
+            "\r\n" +
+            "Key attributes for arbitrary elements are id and name. See `Introduction` for details about log levels and locators.")
+    @ArgumentNames({ "locator" })
+    public void elementShouldBeFocused(String locator) {
+        if (!isFocused(locator)) {
+            throw new SeleniumLibraryNonFatalException(String.format("Element %s is disabled.", locator));
         }
     }
 
@@ -582,11 +592,20 @@ public class Element extends RunOnFailureKeywordsAdapter {
         action.doubleClick(elements.get(0)).perform();
     }
 
-    @RobotKeyword("Set the focus to the element identified by ``locator``.\r\n" + 
-            "\r\n" + 
+    @RobotKeyword("Set the focus to the element identified by ``locator``.\r\n" +
+            "\r\n" +
             "Key attributes for arbitrary elements are id and name. See `Introduction` for details about locators.")
     @ArgumentNames({ "locator" })
+    @Deprecated
     public void focus(String locator) {
+        setFocusToElement(locator);
+    }
+
+    @RobotKeyword("Set the focus to the element identified by ``locator``.\r\n" +
+            "\r\n" +
+            "Key attributes for arbitrary elements are id and name. See `Introduction` for details about locators.")
+    @ArgumentNames({ "locator" })
+    public void setFocusToElement(String locator) {
         List<WebElement> elements = elementFind(locator, true, true);
         ((JavascriptExecutor) browserManagement.getCurrentWebDriver()).executeScript("arguments[0].focus();",
                 elements.get(0));
@@ -975,6 +994,14 @@ public class Element extends RunOnFailureKeywordsAdapter {
         }
 
         return true;
+    }
+
+    protected boolean isFocused(String locator) {
+        List<WebElement> elements = elementFind(locator, true, true);
+        WebElement element = elements.get(0);
+        WebDriver current = browserManagement.getCurrentWebDriver();
+        WebElement focused = current.switchTo().activeElement();
+        return element.equals(focused);
     }
 
     protected boolean isVisible(String locator) {

--- a/src/main/java/com/github/markusbernhardt/seleniumlibrary/keywords/Element.java
+++ b/src/main/java/com/github/markusbernhardt/seleniumlibrary/keywords/Element.java
@@ -273,7 +273,7 @@ public class Element extends RunOnFailureKeywordsAdapter {
     @ArgumentNames({ "locator" })
     public void elementShouldBeFocused(String locator) {
         if (!isFocused(locator)) {
-            throw new SeleniumLibraryNonFatalException(String.format("Element %s is disabled.", locator));
+            throw new SeleniumLibraryNonFatalException(String.format("Element %s is not focused.", locator));
         }
     }
 


### PR DESCRIPTION
Added the new Set Focus To Element keyword which replaces the Focus keyword. For backwards compatibility, the old Focus keyword has been left in there but has been marked as deprecated.

Also added the companion keyword Element Should Be Focused to detect if a given element has focus.

This PR doesn not need an immediate release.