### PR TITLE
Fix for Get Element Attribute overloading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 target
 webdriver
 /libspecs/
+.idea

--- a/src/main/java/com/github/markusbernhardt/seleniumlibrary/keywords/Element.java
+++ b/src/main/java/com/github/markusbernhardt/seleniumlibrary/keywords/Element.java
@@ -423,20 +423,6 @@ public class Element extends RunOnFailureKeywordsAdapter {
         }
     }
 
-    @RobotKeyword("Returns the value of an element attribute.\r\n" +
-            "\r\n" +
-            "The ``attribute_locator`` consists of element locator followed by an @ sign and attribute name. Example: element_id@class\r\n" +
-            "\r\n" +
-            "Key attributes for arbitrary elements are id and name. See `Introduction` for details about locators.\r\n" +
-            "\r\n" +
-            "Passing attribute name as part of the locator was removed in SeleniumLibrary 3.2. The explicit attribute argument should be used instead.")
-    @ArgumentNames({ "attributeLocator" })
-    @Deprecated
-    public String getElementAttribute(String attributeLocator) {
-        String[] parts = parseAttributeLocator(attributeLocator);
-        return getElementAttribute(parts[0], parts[1]);
-    }
-
     @RobotKeyword("Returns value of attribute from element locator.\r\n" +
             "\r\n" +
             "See the `Locating elements` section for details about the locator syntax.\r\n" +
@@ -444,14 +430,23 @@ public class Element extends RunOnFailureKeywordsAdapter {
             "Example: ${id}=    Get Element Attribute   css:h1  id\r\n" +
             "\r\n" +
             "Passing attribute name as part of the locator was removed in SeleniumLibrary 3.2. The explicit attribute argument should be used instead.")
-    @ArgumentNames({ "locator", "attribute" })
-    public String getElementAttribute(String locator, String attribute) {
-        List<WebElement> elements = elementFind(locator, true, false);
+    @ArgumentNames({ "locator", "attribute=None" })
+    public String getElementAttribute(String... params) {
+        String locator = robot.getParamsValue(params, 0, "");
+        String attribute = robot.getParamsValue(params, 1, "");
+        String loc = locator;
+        String attr = attribute;
+        if (StringUtils.isEmpty(attribute)) {
+            String[] parts = parseAttributeLocator(locator);
+            loc = parts[0];
+            attr = parts[1];
+        }
+        List<WebElement> elements = elementFind(loc, true, false);
 
         if (elements.size() == 0) {
-            throw new SeleniumLibraryNonFatalException(String.format("Element '%s' not found.", locator));
+            throw new SeleniumLibraryNonFatalException(String.format("Element '%s' not found.", loc));
         }
-        return elements.get(0).getAttribute(attribute);
+        return elements.get(0).getAttribute(attr);
     }
 
     @RobotKeyword("Clears the text from element identified by ``locator``.\r\n" +


### PR DESCRIPTION
turns out it is not possible to work with overloaded methods when it comes to RF. So the old, 1 parameter, method had to be removed completely.

This also means a slightly different (uglier) way of getting the locator and attribute in there to keep everything backwards compatible.

The only way to get around using this uglier way is to break backwards compatibility though so this would seem the lesser of two evils for now.